### PR TITLE
set host to default_host in case it is not "localhost"

### DIFF
--- a/globaladdressbook.php
+++ b/globaladdressbook.php
@@ -25,6 +25,7 @@ class globaladdressbook extends rcube_plugin
 		$this->load_config();
 		$this->add_texts('localization/');
 
+		$this->host = $rcmail->config->get('default_host');
 		$this->user_name = $rcmail->config->get('globaladdressbook_user');
 		$this->user_name = str_replace('%d', $rcmail->user->get_username('domain'), $this->user_name);
 		$this->user_name = str_replace('%h', $_SESSION['storage_host'], $this->user_name);


### PR DESCRIPTION
Recently upgraded to 1.0.x and lost my global address book as a new global address book user was created in 'localhost' vs our setting of '127.0.0.1'
