### PR TITLE
Add localisations to override DEFAULT_NAME

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 Roundcube Webmail GlobalAddressbook
 ===================================
 
+ * Add localisations to override DEFAULT_NAME
+
 Version 2.0 (2021-01-03, rc-1.3)
 =================================================
  * Complete rewrite of config options

--- a/globaladdressbook.php
+++ b/globaladdressbook.php
@@ -44,6 +44,7 @@ class globaladdressbook extends rcube_plugin
         $this->rcube = rcube::get_instance();
 
         $this->_load_config();
+        $this->add_texts('localization/');
 
         // Host exceptions
         $hosts = $this->rcube->config->get('globaladdressbook_allowed_hosts');
@@ -76,7 +77,7 @@ class globaladdressbook extends rcube_plugin
         foreach ($this->abook_ids as $id) {
             $args['sources'][$id] = [
                 'id' => $id,
-                'name' => $this->_get_config('name', $id, self::DEFAULT_NAME),
+                'name' => rcmail::Q($this->gettext('globaladdressbooks_'.$id)) ?: $this->_get_config('name', $id, self::DEFAULT_NAME),
                 'readonly' => $this->_get_config('readonly', $id),
                 'groups' => $this->_get_config('groups', $id, false),
             ];
@@ -91,7 +92,7 @@ class globaladdressbook extends rcube_plugin
             $args['instance'] = new rcube_contacts($this->rcube->db, $this->_get_config('user_id', $args['id']));
             $args['instance']->readonly = $this->_get_config('readonly', $args['id']);
             $args['instance']->groups = $this->_get_config('groups', $args['id'], false);
-            $args['instance']->name = $this->_get_config('name', $args['id'], self::DEFAULT_NAME);
+            $args['instance']->name = rcmail::Q($this->gettext('globaladdressbooks_'.$args['id'])) ?: $this->_get_config('name', $args['id'], self::DEFAULT_NAME);
         }
 
         return $args;

--- a/localization/en_GB.inc
+++ b/localization/en_GB.inc
@@ -1,0 +1,9 @@
+<?php
+/* Author: Philip Weir */
+
+/* index format: 'globaladdressbooks_'.$id (default value for $id: 'global') */
+
+$labels = array();
+$labels['globaladdressbooks_global'] = 'Shared contacts';
+
+$messages = array();

--- a/localization/en_US.inc
+++ b/localization/en_US.inc
@@ -1,0 +1,9 @@
+<?php
+/* Author: Philip Weir */
+
+/* index format: 'globaladdressbooks_'.$id (default value for $id: 'global') */
+
+$labels = array();
+$labels['globaladdressbooks_global'] = 'Shared contacts';
+
+$messages = array();

--- a/localization/it_IT.inc
+++ b/localization/it_IT.inc
@@ -1,0 +1,9 @@
+<?php
+/* Author: Gianluca Giacometti*/
+
+/* index format: 'globaladdressbooks_'.$id (default value for $id: 'global') */
+
+$labels = array();
+$labels['globaladdressbooks_global'] = 'Contatti condivisi';
+
+$messages = array();


### PR DESCRIPTION
Sometimes the default name of a global address book needs to be translated into different languages (i.e. in an international environment such as a University).
I took some localisation files from the version 1 of your plugin and made a slight change to the code.
This is the simplest way I could find. Of course it requires administrators to create their own localisation files, but I guess this addition is a plus anyway.