### PR TITLE
fix for issue preventing pkgs installation in composer

### DIFF
--- a/globaladdressbook.php
+++ b/globaladdressbook.php
@@ -246,7 +246,7 @@ class globaladdressbook extends rcube_plugin
         $user = $this->rcube->user;
 
         // %h - IMAP host
-        $h = $_SESSION['storage_host'];
+        $h = $_SESSION['storage_host'] ?? null;
         // %d - domain name after the '@' from username
         $d = $user->get_username('domain');
         // %i - domain name after the '@' from e-mail address of default identity


### PR DESCRIPTION
this fixes an issue which prevents installation/update/removal of ANY package with composer (in PHP8)

example stack trace below
Installs: jfcherng-roundcube/show-folder-size:0.7.13
Reading /root/.composer/cache/files/jfcherng-roundcube/show-folder-size/f7d3951a646a09eae4fba88b9a455b671b020e0d.zip from cache
  - Loading jfcherng-roundcube/show-folder-size (0.7.13) from cache
    Install of jfcherng-roundcube/show-folder-size failed


  [ErrorException]
  Undefined array key "storage_host"


Exception trace:
 () at /var/www/roundcube/plugins/globaladdressbook/globaladdressbook.php:249
 Composer\Util\ErrorHandler::handle() at /var/www/roundcube/plugins/globaladdressbook/globaladdressbook.php:249
 globaladdressbook->_parse_macros() at /var/www/roundcube/plugins/globaladdressbook/globaladdressbook.php:158
 globaladdressbook->_load_config() at /var/www/roundcube/plugins/globaladdressbook/globaladdressbook.php:46
 globaladdressbook->init() at /var/www/roundcube/program/lib/Roundcube/rcube_plugin_api.php:105
 rcube_plugin_api->init() at /var/www/roundcube/program/include/rcmail.php:153
 rcmail->startup() at /var/www/roundcube/program/include/rcmail.php:86